### PR TITLE
add back removed permisison, users cannot download

### DIFF
--- a/com.ktechpit.ultimate-media-downloader.yaml
+++ b/com.ktechpit.ultimate-media-downloader.yaml
@@ -18,6 +18,13 @@ finish-args:
   - --system-talk-name=org.freedesktop.GeoClue2
   - --system-talk-name=org.freedesktop.UPower.*
 
+  # download directories for convenience
+  - --filesystem=xdg-desktop
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-videos
+
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
Write access to these directories removed in recent commits, broke download functionality for users. Adding them back. 

issues reported by users 
- https://github.com/keshavbhatt/ultimate-media-downloader-linux/issues/65
- https://github.com/keshavbhatt/ultimate-media-downloader-linux/issues/66